### PR TITLE
passwordless sudo for DnsAdmins group

### DIFF
--- a/scripts/pcluster_head_node.sh
+++ b/scripts/pcluster_head_node.sh
@@ -166,3 +166,8 @@ aws s3 cp /etc/ood/config/clusters.d/$STACK_NAME.yml s3://$S3_CONFIG_BUCKET/clus
 cat >> /etc/bashrc << 'EOF'
 PATH=$PATH:/shared/software/bin
 EOF
+
+# Give AD group with Admin user passwordless sudo
+cat >> /etc/sudoers.d/99-admin-ad-users << 'EOF'
+%DnsAdmins ALL=(ALL) NOPASSWD:ALL
+EOF

--- a/scripts/pcluster_worker_node.sh
+++ b/scripts/pcluster_worker_node.sh
@@ -43,3 +43,8 @@ systemctl restart sssd
 cat >> /etc/bashrc << 'EOF'
 PATH=$PATH:/shared/software/bin
 EOF
+
+# Give AD group with Admin user passwordless sudo
+cat >> /etc/sudoers.d/99-admin-ad-users << 'EOF'
+%DnsAdmins ALL=(ALL) NOPASSWD:ALL
+EOF

--- a/scripts/pcluster_worker_node_desktop.sh
+++ b/scripts/pcluster_worker_node_desktop.sh
@@ -70,6 +70,11 @@ PATH=$PATH:/opt/TurboVNC/bin:/shared/software/bin
 export XDG_RUNTIME_DIR="$HOME/.cache/dconf"
 EOF
 
+# Give AD group with Admin user passwordless sudo
+cat >> /etc/sudoers.d/99-admin-ad-users << 'EOF'
+%DnsAdmins ALL=(ALL) NOPASSWD:ALL
+EOF
+
 #
 #wget https://download2.rstudio.org/server/centos7/x86_64/rstudio-server-rhel-2023.03.0-386-x86_64.rpm
 # run this on compute node


### PR DESCRIPTION
Grants the Admin user passwordless sudo. Necessary for imaging team development.